### PR TITLE
Add STONE (Bloodstone) UTXO coin

### DIFF
--- a/coins
+++ b/coins
@@ -17270,5 +17270,61 @@
       "github": "https://github.com/casraw/cascoin",
       "homepage": "https://cascoin.net"
     }
+  },
+  {
+    "coin": "STONE",
+    "name": "bloodstone",
+    "fname": "Bloodstone",
+    "sign_message_prefix": "SpaceXpanse Signed Message:\n",
+    "rpcport": 18332,
+    "pubtype": 63,
+    "p2shtype": 125,
+    "wiftype": 191,
+    "txfee": 10000,
+    "dust": 546,
+    "segwit": true,
+    "bech32_hrp": "stone",
+    "mm2": 1,
+    "wallet_only": false,
+    "required_confirmations": 6,
+    "avg_blocktime": 30,
+    "protocol": {
+      "type": "UTXO"
+    },
+    "derivation_path": "m/44'/1899'",
+    "links": {
+      "github": "https://github.com/SpaceXpanse/rod-core-wallet",
+      "homepage": "https://bloodstonewallet.mytunnel.org/"
+    }
+  },
+  {
+    "coin": "STONE-segwit",
+    "name": "bloodstone",
+    "fname": "Bloodstone",
+    "sign_message_prefix": "SpaceXpanse Signed Message:\n",
+    "rpcport": 18332,
+    "pubtype": 63,
+    "p2shtype": 125,
+    "wiftype": 191,
+    "txfee": 10000,
+    "dust": 546,
+    "segwit": true,
+    "bech32_hrp": "stone",
+    "address_format": {
+      "format": "segwit"
+    },
+    "orderbook_ticker": "STONE",
+    "mm2": 1,
+    "wallet_only": false,
+    "required_confirmations": 6,
+    "avg_blocktime": 30,
+    "protocol": {
+      "type": "UTXO"
+    },
+    "derivation_path": "m/84'/1899'",
+    "links": {
+      "github": "https://github.com/SpaceXpanse/rod-core-wallet",
+      "homepage": "https://bloodstonewallet.mytunnel.org/"
+    }
   }
 ]

--- a/electrums/STONE
+++ b/electrums/STONE
@@ -1,0 +1,22 @@
+[
+  {
+    "url": "electrum.bloodstonewallet.mytunnel.org:50001",
+    "contact": [
+      {
+        "email": "support@bloodstonewallet.mytunnel.org",
+        "url": "https://bloodstonewallet.mytunnel.org/support/"
+      }
+    ]
+  },
+  {
+    "url": "electrum.bloodstonewallet.mytunnel.org:50002",
+    "protocol": "SSL",
+    "contact": [
+      {
+        "email": "support@bloodstonewallet.mytunnel.org",
+        "url": "https://bloodstonewallet.mytunnel.org/support/"
+      }
+    ],
+    "ws_url": "electrum.bloodstonewallet.mytunnel.org:50003"
+  }
+]

--- a/explorers/STONE
+++ b/explorers/STONE
@@ -1,0 +1,3 @@
+[
+  "https://bloodstonewallet.mytunnel.org/explorer/"
+]


### PR DESCRIPTION
## Add STONE (Bloodstone) UTXO coin

Bloodstone (ticker **STONE**) is a SpaceXpanse/ROD-fork UTXO chain relaunched 22 Jun 2026 with a new genesis.

### Chain parameters
| Field | Value |
|-------|-------|
| Ticker | `STONE` / `STONE-segwit` |
| P2P | `64.188.22.190:17333` |
| RPC | `18332` |
| pubtype / p2shtype / wiftype | `63` / `125` / `191` |
| bech32 HRP | `stone` |
| sign_message_prefix | `SpaceXpanse Signed Message:\n` |
| genesis | `df04225074039e630dad825b24818a695462bd19cd585131a0568f50e9bf71d0` |
| avg blocktime | ~30s |

### Infrastructure
- **Explorer:** https://bloodstonewallet.mytunnel.org/explorer/
- **ElectrumX SSL:** `electrum.bloodstonewallet.mytunnel.org:50002` (live, synced)
- **ElectrumX TCP:** `electrum.bloodstonewallet.mytunnel.org:50001`
- **Support:** https://bloodstonewallet.mytunnel.org/support/

### Test swap
Happy to provide a test STONE address with balance on request in `#dev-support`.